### PR TITLE
fix: resolve desktop executable trust dialog on container restart

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
 set -e
-
 # Run as root to install cronitor and set permissions
 if [ "$(id -u)" = "0" ]; then
     # Set the uid and gid based on environment variables PUID/PGID
@@ -14,7 +12,6 @@ if [ "$(id -u)" = "0" ]; then
     else
         echo "PUID or PGID not set. Using default values."
     fi
-
     # Install cronitor
     if [ -n "$CRONITOR_API_KEY" ]; then
         echo "Installing cronitor..."
@@ -27,22 +24,33 @@ if [ "$(id -u)" = "0" ]; then
     else
         echo "CRONITOR_API_KEY not set. Skipping cronitor installation."
     fi
-
     # Start cron daemon as root
     echo "Starting the cron daemon"
     cron
     echo "The cron daemon started successfully."
-
     # Give execution rights on the cron job
     crontab -u iptvboss /headless/iptvboss-cron &&  \
     chmod u+s /usr/sbin/cron && \
     touch /var/log/cron.log && \
     chown iptvboss:iptvboss /var/log/cron.log
-
+    # Fix XFCE trust for desktop executable files (fixes "Untrusted application launcher" dialog)
+    # See: https://github.com/groenator/iptvboss-docker/issues/206
+    mkdir -p /headless/.config/xfce4/xfconf/xfce-perchannel-xml
+    if [ ! -f /headless/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml ]; then
+        printf '<?xml version="1.0" encoding="UTF-8"?>\n<channel name="thunar" version="1.0">\n  <property name="misc-exec-shell-scripts-as-executable" type="bool" value="true"/>\n</channel>\n' \
+            > /headless/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml
+    fi
+    # Restore gvfs-metadata trust checksum if it exists from a previous run
+    mkdir -p /headless/.local/share/gvfs-metadata
+    if [ -f /headless/IPTVBoss/gvfs-metadata-home ]; then
+        cp /headless/IPTVBoss/gvfs-metadata-home /headless/.local/share/gvfs-metadata/home
+        chmod 600 /headless/.local/share/gvfs-metadata/home
+    fi
+    chown -R ${PUID}:${PGID} /headless/.config
+    chown -R ${PUID}:${PGID} /headless/.local
     # Change to iptvboss user for user-level commands
     exec gosu iptvboss "$BASH_SOURCE" "$@"
 fi
-
 # The following will run as iptvboss user due to gosu command above
 if [ -n "$CRON_SCHEDULE" ]; then
     echo "Configuring Cron schedule for iptvboss user..."
@@ -57,7 +65,6 @@ if [ -n "$CRON_SCHEDULE" ]; then
 else
     echo "CRON_SCHEDULE not set. No cron job configured for iptvboss."
 fi
-
 # Configure cronitor if API key is provided
 if [ -n "$CRONITOR_API_KEY" ]; then
     configure_cronitor() {
@@ -65,7 +72,6 @@ if [ -n "$CRONITOR_API_KEY" ]; then
     }
     configure_cronitor
 fi
-
 # # Start XCServer on Boot
 if [ "$XC_SERVER" = "true" ]; then
     echo "Starting XCServer..."
@@ -74,7 +80,6 @@ if [ "$XC_SERVER" = "true" ]; then
 else
     echo "XC_SERVER is not set to true. XCServer will not be started."
 fi
-
 #Start vnc service
 sleep 5
 echo "Staring The VNC service"


### PR DESCRIPTION
Fixes #206

- Configure XFCE/Thunar xfconf to trust executable desktop files
- Restore gvfs-metadata trust checksum on container startup
- Prevents "Untrusted application launcher" dialog from appearing after redeployment