### PR TITLE
Improve noVNC access and set Firefox as default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,31 @@ docker run -it -p 5901:5901 -p 6901:6901 -p 8001:8001
 -v <your-local-volume>:/headless/IPTVBoss
 ghcr.io/groenator/iptvboss-docker:latest
 ```
+
+## Full noVNC client and browser clipboard
+
+For browser access, the full noVNC client is recommended:
+
+```text
+http://<host-ip>:6901/vnc.html?autoconnect=true&password=vncpassword&resize=scale
+```
+
+The full noVNC client provides the browser toolbar and clipboard controls, which makes copy/paste work better from the browser.
+
+The lite noVNC client is still available:
+
+```text
+http://<host-ip>:6901/?password=vncpassword
+```
+
+## Dropbox authorization links
+
+If Dropbox authorization links do not open, make sure the desktop default browser is set to Mozilla Firefox.
+
+Inside the VNC desktop:
+
+```text
+Applications → Settings → Default Applications → Internet → Web Browser → Mozilla Firefox
+```
+
+The container now sets Mozilla Firefox as the default XFCE/XDG web browser when no existing user preference is found.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,56 @@ if [ "$(id -u)" = "0" ]; then
     chmod u+s /usr/sbin/cron && \
     touch /var/log/cron.log && \
     chown iptvboss:iptvboss /var/log/cron.log
+# Set Mozilla Firefox as the default browser for XFCE/XDG when no user preference exists.
+# This helps external authorization links, such as Dropbox auth links, open correctly.
+FIREFOX_CMD="$(command -v firefox || command -v firefox-esr || true)"
+
+if [ -n "$FIREFOX_CMD" ]; then
+  mkdir -p /headless/.config/xfce4
+  mkdir -p /headless/.config
+  mkdir -p /headless/.local/share/applications
+
+  if [ ! -f /headless/.config/xfce4/helpers.rc ] || ! grep -q '^WebBrowser=' /headless/.config/xfce4/helpers.rc; then
+    echo "Setting Mozilla Firefox as the default XFCE web browser..."
+    printf 'WebBrowser=firefox\n' > /headless/.config/xfce4/helpers.rc
+  fi
+
+  if [ ! -f /headless/.local/share/applications/firefox.desktop ]; then
+    echo "Creating Mozilla Firefox XDG desktop entry..."
+    cat > /headless/.local/share/applications/firefox.desktop <<EOF2
+[Desktop Entry]
+Type=Application
+Name=Mozilla Firefox
+Exec=$FIREFOX_CMD %U
+Icon=firefox
+Terminal=false
+Categories=Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;
+EOF2
+  fi
+
+  if [ ! -f /headless/.config/mimeapps.list ]; then
+    echo "Setting Mozilla Firefox as the default XDG handler for web links..."
+    cat > /headless/.config/mimeapps.list <<'EOF2'
+[Default Applications]
+text/html=firefox.desktop
+text/xml=firefox.desktop
+application/xhtml+xml=firefox.desktop
+x-scheme-handler/http=firefox.desktop
+x-scheme-handler/https=firefox.desktop
+
+[Added Associations]
+text/html=firefox.desktop;
+text/xml=firefox.desktop;
+application/xhtml+xml=firefox.desktop;
+x-scheme-handler/http=firefox.desktop;
+x-scheme-handler/https=firefox.desktop;
+EOF2
+  fi
+else
+  echo "Mozilla Firefox command not found. Skipping default browser setup."
+fi
+
     # Fix XFCE trust for desktop executable files (fixes "Untrusted application launcher" dialog)
     # See: https://github.com/groenator/iptvboss-docker/issues/206
     mkdir -p /headless/.config/xfce4/xfconf/xfce-perchannel-xml


### PR DESCRIPTION
## Summary

This PR improves the browser-based VNC experience and fixes Dropbox authorization links inside the IPTVBoss desktop.

## Changes

- Documents the full noVNC client URL:
  - `/vnc.html?autoconnect=true&password=<password>&resize=scale`
- Keeps the existing lite noVNC URL documented as an alternative:
  - `/?password=<password>`
- Sets **Mozilla Firefox** as the default browser in the XFCE desktop config when no user preference exists.
- Adds XDG MIME defaults for `http`, `https`, and HTML links using `firefox.desktop`.

## Why

The full noVNC client exposes the toolbar and clipboard controls, which makes copy/paste work properly from the browser.

Dropbox authorization can fail because IPTVBoss may try to open the auth link with Debian Sensible Browser. Setting the default browser to **Mozilla Firefox** fixes this behavior.

## Tested

Validated on **Unraid** using a locally built image:

```text
local/iptvboss-docker:pr-test
```

Browser WebUI tested with:

```text
http://10.13.1.138:6902/vnc.html?autoconnect=true&password=iptvboss&resize=scale
```

Confirmed on Unraid:

- Browser noVNC opens correctly.
- Copy/paste works from the browser.
- IPTVBoss opens normally.
- Mozilla Firefox is available and set as the default browser.
- XFCE helper shows `WebBrowser=firefox`.
- XDG handlers point `http` and `https` to `firefox.desktop`.
- Existing `PUID`, `PGID`, cron, XC Server, VNC/noVNC, and `/headless/IPTVBoss` behavior remain unchanged.

## Docker / Docker Compose note

Although this was validated on Unraid, the default-browser changes are made inside the container startup flow and should also apply to standard Docker or Docker Compose deployments that use the same image and `/headless` layout.

Docker Compose users should still be able to access the full noVNC client with:

```text
http://<host-ip>:6901/vnc.html?autoconnect=true&password=<password>&resize=scale
```

## Notes

This keeps the existing container behavior intact while improving the browser-based setup experience for users who access IPTVBoss through noVNC.