### PR TITLE
fix: give the iptvboss user ownership of its cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,16 @@ RUN useradd -u 911 -U -d /headless -s /bin/bash iptvboss && \
     chown iptvboss:iptvboss /headless/iptvboss-cron && \
     chmod 600 /headless/iptvboss-cron
 
+# The base image creates /headless/.cache owned by root with mode 0700, but the
+# iptvboss user runs the app and the graphics libraries it pulls in. Mesa fails
+# to create its shader cache under $XDG_CACHE_HOME (/headless/.cache) as a
+# result. The entrypoint only chowns /headless when PUID/PGID are set, so give
+# the cache dir to iptvboss at build time. This also lets Chromium, dconf and
+# the other user caches populate cleanly.
+RUN mkdir -p /headless/.cache && \
+    chown iptvboss:iptvboss /headless/.cache && \
+    chmod 700 /headless/.cache
+
 # Expose VNC port
 EXPOSE 5901
 EXPOSE 6901

--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -48,6 +48,13 @@ RUN useradd -u 911 -U -d /headless -s /bin/bash iptvboss && \
     chown iptvboss:iptvboss /headless/iptvboss-cron && \
     chmod 600 /headless/iptvboss-cron
 
+# Ensure the iptvboss user owns its cache dir so Mesa (and other graphics libs
+# the app pulls in) can create their shader cache under $XDG_CACHE_HOME. The
+# entrypoint only chowns /headless when PUID/PGID are set.
+RUN mkdir -p /headless/.cache && \
+    chown iptvboss:iptvboss /headless/.cache && \
+    chmod 700 /headless/.cache
+
 # Copy the xcserver file
 COPY xcserver.sh /headless/xcserver.sh
 


### PR DESCRIPTION
## Summary

The base image creates `/headless/.cache` as `root:root 0700`, but the `iptvboss` user (uid 911) runs the app and the graphics libraries it pulls in — so Mesa can't create its shader cache and logs `Failed to create /headless/.cache/mesa_shader_cache for shader cache (Permission denied)---disabling.` on startup.

This creates `/headless/.cache` and hands it to `iptvboss` at build time in both Dockerfiles, so Chromium, dconf and the other user caches benefit from the same fix.

#227 tackles the issue by moving the user's home to `/headless/iptvboss`, but this crashes the container at startup: `vnc_startup.sh` sources `$HOME/.bashrc`, which no longer exists, plus other similar issues.

## Testing I did

Built `Dockerfile` with `LATEST_TAG=3.10.5` and ran it (`XC_SERVER=true`, no cache override):
- `/headless/.cache` is now `iptvboss:iptvboss 0700`.
- Mesa creates `/headless/.cache/mesa_shader_cache` at runtime — no permission error.
- VNC/desktop starts normally; no regression.

Closes #138
